### PR TITLE
feat/지역필터링 기능 구현 및 RegionCode API 연동

### DIFF
--- a/src/main/java/org/iebbuda/mozi/config/RootConfig.java
+++ b/src/main/java/org/iebbuda/mozi/config/RootConfig.java
@@ -22,7 +22,7 @@ import javax.sql.DataSource;
 @PropertySource({"classpath:/application.properties"})
 @EnableTransactionManagement
 @MapperScan(basePackages = {"org.iebbuda.mozi.domain.user.mapper", "org.iebbuda.mozi.domain.policy.mapper", "org.iebbuda.mozi.domain.product.mapper","org.iebbuda.mozi.domain.profile.mapper"})
-@ComponentScan(basePackages = {"org.iebbuda.mozi.domain.user.service", "org.iebbuda.mozi.domain.policy.service", "org.iebbuda.mozi.domain.product.scheduler",
+@ComponentScan(basePackages = {"org.iebbuda.mozi.domain.user.service", "org.iebbuda.mozi.domain.policy.service", "org.iebbuda.mozi.domain.policy.util", "org.iebbuda.mozi.domain.product.scheduler",
         "org.iebbuda.mozi.domain.product.service","org.iebbuda.mozi.domain.profile.service"})
 
 

--- a/src/main/java/org/iebbuda/mozi/domain/policy/controller/PolicyController.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/controller/PolicyController.java
@@ -2,6 +2,7 @@ package org.iebbuda.mozi.domain.policy.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.iebbuda.mozi.domain.policy.dto.PolicyDTO;
+import org.iebbuda.mozi.domain.policy.dto.PolicyFilterDTO;
 import org.iebbuda.mozi.domain.policy.service.PolicyService;
 import org.iebbuda.mozi.domain.policy.util.ApiCaller;
 import org.springframework.http.ResponseEntity;
@@ -43,5 +44,12 @@ public class PolicyController {
         PolicyDTO dto = policyService.findById(id);
         return ResponseEntity.ok(dto);
     }
+
+    @PostMapping("/filter")
+    public List<PolicyDTO> getFilteredPolicies(@RequestBody PolicyFilterDTO filters) {
+        return policyService.getPoliciesByFilters(filters);
+    }
+
+
 
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/controller/RegionCodeController.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/controller/RegionCodeController.java
@@ -1,0 +1,43 @@
+package org.iebbuda.mozi.domain.policy.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.iebbuda.mozi.domain.policy.domain.RegionCodeVO;
+import org.iebbuda.mozi.domain.policy.service.RegionCodeService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/region")
+@RequiredArgsConstructor
+public class RegionCodeController {
+
+    private final RegionCodeService regionCodeService;
+
+    @PostMapping("/zipcodes")
+    public List<String> getZipCodesByRegionNames(@RequestBody List<String> regionNames) {
+        return regionCodeService.getZipCodesByRegionNames(regionNames);
+    }
+
+    @PostMapping("/add")
+    public void insertRegionCode(@RequestBody RegionCodeVO regionCode) {
+        regionCodeService.saveRegionCode(regionCode);
+    }
+
+    @GetMapping("/all")
+    public List<RegionCodeVO> getAllRegionCodes() {
+        return regionCodeService.getAllRegionCodes();
+    }
+
+    @PostMapping("/names")
+    public List<String> getRegionNamesByZipCodes(@RequestBody List<String> zipCodes) {
+        return regionCodeService.getRegionNamesByZipCodes(zipCodes);
+    }
+    // zipCd DB에 저장
+    @PostMapping("/fetch")
+    public ResponseEntity<String> fetchAndSave() {
+        regionCodeService.fetchAndSaveFromApi();
+        return ResponseEntity.ok(" RegionCode DB 저장 완료");
+    }
+}

--- a/src/main/java/org/iebbuda/mozi/domain/policy/domain/PolicyVO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/domain/PolicyVO.java
@@ -26,8 +26,8 @@ public class PolicyVO {
     private String plcyKywdNm;         // 키워드
     private Integer sprtTrgtMinAge;    // 최소 나이
     private Integer sprtTrgtMaxAge;    // 최대 나이
-    private String earnCndSeCd;
-    private Integer earnMinAmt;
-    private Integer earnMaxAmt;
-    private String earnEtcCn;
+    private String earnCndSeCd;        // 소득조건
+    private Integer earnMinAmt;         //최소 소득
+    private Integer earnMaxAmt;         // 최대소득
+    private String earnEtcCn;           //소득 기타
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/domain/RegionCodeVO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/domain/RegionCodeVO.java
@@ -1,0 +1,11 @@
+package org.iebbuda.mozi.domain.policy.domain;
+
+import lombok.Data;
+
+@Data
+public class RegionCodeVO {
+    private int regionId;
+    private String sido;
+    private String sigungu;
+    private String zipCode;
+}

--- a/src/main/java/org/iebbuda/mozi/domain/policy/dto/PolicyFilterDTO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/dto/PolicyFilterDTO.java
@@ -1,0 +1,16 @@
+package org.iebbuda.mozi.domain.policy.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class PolicyFilterDTO {
+    private String marital_status; // 혼인여부 단일 선택
+    private List<String> region;
+    private List<String> job;
+    private List<String> education;
+    private List<String> major;
+    private List<String> specialty;
+    private Integer age;
+}

--- a/src/main/java/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.java
@@ -1,6 +1,8 @@
 package org.iebbuda.mozi.domain.policy.mapper;
 
 import org.iebbuda.mozi.domain.policy.domain.PolicyVO;
+import org.iebbuda.mozi.domain.policy.dto.PolicyDTO;
+import org.iebbuda.mozi.domain.policy.dto.PolicyFilterDTO;
 import org.mapstruct.Mapper;
 
 import java.util.List;
@@ -12,5 +14,5 @@ public interface PolicyMapper {
     void insertPolicy(PolicyVO policyVO);
 
     PolicyVO selectPolicyById(int id);
-
+    List<PolicyDTO> findByFilters(PolicyFilterDTO filters);
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/mapper/RegionCodeMapper.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/mapper/RegionCodeMapper.java
@@ -1,0 +1,21 @@
+package org.iebbuda.mozi.domain.policy.mapper;
+
+import org.iebbuda.mozi.domain.policy.domain.RegionCodeVO;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface RegionCodeMapper {
+    void insertRegionCode(RegionCodeVO regionCode);
+
+    List<String> findZipCodesByRegionNames(List<String> regionNames); // 예: ["서울특별시 강북구", "경기도 성남시"]
+
+    List<String> findRegionNamesByZipCodes(List<String> zipCodes);
+
+    List<RegionCodeVO> findAll();
+
+    void truncateTable();
+
+
+}

--- a/src/main/java/org/iebbuda/mozi/domain/policy/service/PolicyService.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/service/PolicyService.java
@@ -1,6 +1,7 @@
 package org.iebbuda.mozi.domain.policy.service;
 
 import org.iebbuda.mozi.domain.policy.dto.PolicyDTO;
+import org.iebbuda.mozi.domain.policy.dto.PolicyFilterDTO;
 
 import java.util.List;
 
@@ -11,5 +12,7 @@ public interface PolicyService {
     void saveAll(List<PolicyDTO> dtoList);
 
     PolicyDTO findById(int id);
+
+    List<PolicyDTO> getPoliciesByFilters(PolicyFilterDTO filters);
 
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/service/PolicyServiceImpl.java
@@ -3,6 +3,7 @@ package org.iebbuda.mozi.domain.policy.service;
 import lombok.RequiredArgsConstructor;
 import org.iebbuda.mozi.domain.policy.domain.PolicyVO;
 import org.iebbuda.mozi.domain.policy.dto.PolicyDTO;
+import org.iebbuda.mozi.domain.policy.dto.PolicyFilterDTO;
 import org.iebbuda.mozi.domain.policy.mapper.PolicyMapper;
 import org.springframework.stereotype.Service;
 
@@ -38,6 +39,13 @@ public class PolicyServiceImpl implements PolicyService {
         PolicyVO vo = policyMapper.selectPolicyById(id);
         return toDTO(vo);
     }
+
+    @Override
+    public List<PolicyDTO> getPoliciesByFilters(PolicyFilterDTO filters) {
+        return policyMapper.findByFilters(filters);
+    }
+
+
 
     private PolicyDTO toDTO(PolicyVO vo) {
         PolicyDTO dto = new PolicyDTO();

--- a/src/main/java/org/iebbuda/mozi/domain/policy/service/RegionCodeService.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/service/RegionCodeService.java
@@ -1,0 +1,16 @@
+package org.iebbuda.mozi.domain.policy.service;
+
+import org.iebbuda.mozi.domain.policy.domain.RegionCodeVO;
+
+import java.util.List;
+
+public interface RegionCodeService {
+    List<String> getZipCodesByRegionNames(List<String> regionNames);
+    List<String> getRegionNamesByZipCodes(List<String> zipCodes);
+    void saveRegionCode(RegionCodeVO regionCode);
+    List<RegionCodeVO> getAllRegionCodes();
+
+    // zipCd API 호출 후 저장
+    void fetchAndSaveFromApi();
+
+}

--- a/src/main/java/org/iebbuda/mozi/domain/policy/service/RegionCodeServiceImpl.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/service/RegionCodeServiceImpl.java
@@ -1,0 +1,68 @@
+package org.iebbuda.mozi.domain.policy.service;
+
+import lombok.RequiredArgsConstructor;
+import org.iebbuda.mozi.domain.policy.domain.RegionCodeVO;
+import org.iebbuda.mozi.domain.policy.mapper.RegionCodeMapper;
+import org.iebbuda.mozi.domain.policy.util.RegionCodeApiCaller;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class RegionCodeServiceImpl implements RegionCodeService {
+
+    private final RegionCodeMapper regionCodeMapper;
+    private final RegionCodeApiCaller regionCodeApiCaller;
+
+
+    @Override
+    public List<String> getZipCodesByRegionNames(List<String> regionNames) {
+        return regionCodeMapper.findZipCodesByRegionNames(regionNames);
+    }
+
+    @Override
+    public List<String> getRegionNamesByZipCodes(List<String> zipCodes) {
+        return regionCodeMapper.findRegionNamesByZipCodes(zipCodes);
+    }
+
+    @Override
+    public void saveRegionCode(RegionCodeVO regionCode) {
+        regionCodeMapper.insertRegionCode(regionCode);
+    }
+
+    @Override
+    public List<RegionCodeVO> getAllRegionCodes() {
+        return regionCodeMapper.findAll();
+    }
+
+    // 외부 API 호출 후 DB 저장
+    @Override
+    public void fetchAndSaveFromApi() {
+
+
+        Map<String, Map<String, String>> regionMap = regionCodeApiCaller.fetchAllZipCodes(100, 500);
+        int count = 0;
+
+        for (String sido : regionMap.keySet()) {
+            Map<String, String> sigunguMap = regionMap.get(sido);
+            for (Map.Entry<String, String> entry : sigunguMap.entrySet()) {
+                RegionCodeVO region = new RegionCodeVO();
+                region.setSido(sido);
+                region.setSigungu(entry.getKey());
+                region.setZipCode(entry.getValue());
+
+                try {
+                    regionCodeMapper.insertRegionCode(region);
+                    count++;
+                } catch (Exception e) {
+                    System.out.printf("⚠️ 저장 실패: %s %s (%s)%n", sido, entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        System.out.println("✅ 저장 완료. 총 " + count + "개 저장됨.");
+    }
+
+}

--- a/src/main/java/org/iebbuda/mozi/domain/policy/util/ApiCaller.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/util/ApiCaller.java
@@ -21,7 +21,7 @@ public class ApiCaller {
     private String apiKey;
 
     public String getRequestUrl() {
-        return apiUrl + "?apiKeyNm=" + apiKey + "&rtnType=json&pageNum=1&pageSize=100";
+        return apiUrl + "?apiKeyNm=" + apiKey + "&rtnType=json&pageNum=1&pageSize=200";
     }
 
     public String getJsonResponse() {

--- a/src/main/java/org/iebbuda/mozi/domain/policy/util/RegionCodeApiCaller.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/util/RegionCodeApiCaller.java
@@ -1,0 +1,150 @@
+package org.iebbuda.mozi.domain.policy.util;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+@Getter
+@Setter
+@Component
+public class RegionCodeApiCaller {
+
+    @Value("${zip.api.key}")
+    private String apiKey;
+
+    @Value("${zip.api.url}")
+    private String apiUrl;
+
+    public String getRequestUrl(int page, int perPage) {
+        try {
+            String encodedKey = URLEncoder.encode(apiKey, StandardCharsets.UTF_8);
+            return apiUrl + "?serviceKey=" + encodedKey + "&page=" + page + "&perPage=" + perPage + "&type=json";
+        } catch (Exception e) {
+            throw new RuntimeException("❗ 인증키 인코딩 실패", e);
+        }
+    }
+
+    public Map<String, Map<String, String>> fetchZipCodes(int page, int perPage) {
+        Map<String, Map<String, String>> regionMap = new HashMap<>();
+
+        try {
+            String fullUrl = getRequestUrl(page, perPage);
+            System.out.println("📡 요청 URL: " + fullUrl);
+
+            URL url = new URL(fullUrl);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("GET");
+
+            int responseCode = conn.getResponseCode();
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                StringBuilder response = new StringBuilder();
+
+                try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"))) {
+                    String line;
+                    while ((line = br.readLine()) != null) {
+                        response.append(line);
+                    }
+                }
+
+                parseJson(response.toString(), regionMap);
+            } else {
+                System.out.println("❗ HTTP 오류 코드: " + responseCode);
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return regionMap;
+    }
+
+    public Map<String, Map<String, String>> fetchAllZipCodes(int totalPages, int perPage) {
+        Map<String, Map<String, String>> totalMap = new HashMap<>();
+
+        for (int page = 1; page <= totalPages; page++) {
+            System.out.println("📄 " + page + "페이지 처리 중...");
+            Map<String, Map<String, String>> pageMap = fetchZipCodes(page, perPage);
+
+            // merge
+            for (Map.Entry<String, Map<String, String>> entry : pageMap.entrySet()) {
+                String sido = entry.getKey();
+                Map<String, String> sigunguMap = entry.getValue();
+
+                totalMap.computeIfAbsent(sido, k -> new TreeMap<>())
+                        .putAll(sigunguMap); // 중복 제거됨
+            }
+
+            try {
+                Thread.sleep(300); // 과도한 요청 방지용 딜레이
+            } catch (InterruptedException ignored) {}
+        }
+
+        return totalMap;
+    }
+
+    private void parseJson(String json, Map<String, Map<String, String>> regionMap) {
+        try {
+            JsonObject root = JsonParser.parseString(json).getAsJsonObject();
+            JsonArray data = root.getAsJsonArray("data");
+
+            for (JsonElement elem : data) {
+                JsonObject obj = elem.getAsJsonObject();
+
+                String address = obj.get("법정동명").getAsString();      // "부산광역시 서구 남부민동"
+                String code = obj.get("법정동코드").getAsString();       // 10자리
+                String status = obj.get("폐지여부").getAsString();       // 존재 or 폐지
+
+                if (!"존재".equals(status)) continue;
+
+                String[] parts = address.split(" ");
+                if (parts.length < 2) continue;
+
+                String sido = parts[0];
+
+                // 세종시 예외처리
+                if ("세종특별자치시".equals(sido)) {
+                    regionMap.computeIfAbsent(sido, k -> new TreeMap<>())
+                            .put("세종특별자치시", code.substring(0, 5));
+                    continue;
+                }
+
+                String sigungu;
+                if (parts[1].contains("시") && parts.length > 2) {
+                    if (parts[2].endsWith("구") || parts[2].endsWith("군")) {
+                        sigungu = parts[1] + " " + parts[2];  // ex: 수원시 영통구
+                    } else {
+                        sigungu = parts[1];                  // ex: 익산시
+                    }
+                } else {
+                    sigungu = parts[1];                      // ex: 고성군
+                }
+
+                // 읍/면/동 필터링
+                if (sigungu.endsWith("읍") || sigungu.endsWith("면") || sigungu.endsWith("동")) continue;
+
+                regionMap.computeIfAbsent(sido, k -> new TreeMap<>())
+                        .put(sigungu, code.substring(0, 5)); // 5자리만 사용
+            }
+
+        } catch (Exception e) {
+            System.out.println("❗ JSON 파싱 오류");
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.xml
+++ b/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.xml
@@ -72,4 +72,66 @@
     </select>
 
 
+    <select id="findByFilters" resultType="org.iebbuda.mozi.domain.policy.dto.PolicyDTO">
+        SELECT * FROM YouthPolicy
+        WHERE 1=1
+
+        <!-- 혼인 여부 -->
+        <if test="marital_status != null and marital_status != '0055003'">
+            AND mrgSttsCd = #{marital_status}
+        </if>
+
+        <!-- 지역 필터 -->
+        <if test="region != null and region.size > 0">
+            AND (
+            <foreach collection="region" item="zip" separator=" OR ">
+                zipCd LIKE CONCAT('%', #{zip}, '%')
+            </foreach>
+            )
+        </if>
+
+        <!-- 취업 상태 -->
+        <if test="job != null and job.size > 0">
+            AND jobCd IN
+            <foreach collection="job" item="item" open="(" separator="," close=")">
+                #{item}
+            </foreach>
+        </if>
+
+        <!-- 학력 -->
+        <if test="education != null and education.size > 0">
+            AND schoolCd IN
+            <foreach collection="education" item="item" open="(" separator="," close=")">
+                #{item}
+            </foreach>
+        </if>
+
+        <!-- 전공 -->
+        <if test="major != null and major.size > 0">
+            AND plcyMajorCd IN
+            <foreach collection="major" item="item" open="(" separator="," close=")">
+                #{item}
+            </foreach>
+        </if>
+
+        <!-- 특화 분야 -->
+        <if test="specialty != null and specialty.size > 0">
+            AND sBizCd IN
+            <foreach collection="specialty" item="item" open="(" separator="," close=")">
+                #{item}
+            </foreach>
+        </if>
+
+        <if test="age != null">
+            AND (
+            (sprtTrgtMinAge = 0 OR sprtTrgtMinAge &lt;= #{age})
+            AND
+            (sprtTrgtMaxAge = 0 OR sprtTrgtMaxAge &gt;= #{age})
+            )
+        </if>
+
+
+    </select>
+
+
 </mapper>

--- a/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/RegionCodeMapper.xml
+++ b/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/RegionCodeMapper.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="org.iebbuda.mozi.domain.policy.mapper.RegionCodeMapper">
+
+    <insert id="insertRegionCode" parameterType="org.iebbuda.mozi.domain.policy.domain.RegionCodeVO">
+        INSERT INTO RegionCode (sido, sigungu, zip_code)
+        VALUES (#{sido}, #{sigungu}, #{zipCode})
+    </insert>
+
+    <select id="findZipCodesByRegionNames" resultType="String" parameterType="list">
+        SELECT zip_code
+        FROM RegionCode
+        WHERE CONCAT(sido, ' ', sigungu) IN
+        <foreach item="name" collection="list" open="(" separator="," close=")">
+            #{name}
+        </foreach>
+    </select>
+
+    <select id="findRegionNamesByZipCodes" resultType="String" parameterType="list">
+        SELECT CONCAT(sido, ' ', sigungu)
+        FROM RegionCode
+        WHERE zip_code IN
+        <foreach item="zip" collection="list" open="(" separator="," close=")">
+            #{zip}
+        </foreach>
+    </select>
+
+
+    <select id="findAll" resultType="org.iebbuda.mozi.domain.policy.domain.RegionCodeVO">
+        SELECT * FROM RegionCode
+    </select>
+
+    <delete id="truncateTable">
+        TRUNCATE TABLE RegionCode
+    </delete>
+</mapper>

--- a/src/test/java/org/iebbuda/mozi/domain/policy/util/RegionCodeApiCallerTest.java
+++ b/src/test/java/org/iebbuda/mozi/domain/policy/util/RegionCodeApiCallerTest.java
@@ -1,0 +1,31 @@
+package org.iebbuda.mozi.domain.policy.util;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RegionCodeApiCallerTest {
+
+    public static void main(String[] args) {
+        RegionCodeApiCaller caller = new RegionCodeApiCaller();
+        caller.setApiKey("YOUR_API_KEY");
+        caller.setApiUrl("YOUR_API_URL");
+
+        // Map<시도, Map<구/군, 코드>>
+        Map<String, Map<String, String>> result = caller.fetchAllZipCodes(100, 500);
+
+        int totalCount = 0;
+
+        for (String sido : result.keySet()) {
+            System.out.println("[" + sido + "]");
+            Map<String, String> guMap = result.get(sido);
+            for (Map.Entry<String, String> entry : guMap.entrySet()) {
+                System.out.println("  - " + entry.getKey() + " (" + entry.getValue() + ")");
+                totalCount++;
+            }
+        }
+
+        System.out.println("\n✅ 총 zip 코드 개수: " + totalCount + "개");
+    }
+// ✅ 총 zip 코드 개수: 264개
+}


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [ ] 🐛 버그 수정
- [x] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항
- RegionCodeController, RegionCodeVO, RegionCodeService, RegionCodeMapper 신규 생성
- RegionCodeApiCaller 법정 시군구코드 API 호출 및 DB 저장
- zipCd DB 테이블 신규 생성

</details>

### 왜 이 변경이 필요한가요?
- 정책 필터 및 상세조회에서 지역 필터링을 위한 zipCd -> 지역명 변환 기능 필요
- 지역멍을 프론트에서 하드코딩하지 않고 DB기반 관리


## 📸 스크린샷 (필요한 경우)
<!-- UI 변경사항이 있다면 Before/After 스크린샷을 첨부해주세요 -->

> **Note**  

## ✅ 체크리스트
- [x] OpenAPI 호출 성공 및 DB 저장 확인

## 🚀 테스트 방법
- [x] RegionCode DB 테이블 생성 
- [x] application.properties  인증키 설정 (노션)
- [x] 백엔드 서버 실행
- [x] POST http://localhost:8080/api/region/fetch 요청 
- [x] DB에 zip_code, sido, sigungu 정보 264개 저장 여부 확인
- [x] 프론트에서 필터링 테스트
```bash
