### PR TITLE
정책 api 자동 DB저장 변환

### DIFF
--- a/src/main/java/org/iebbuda/mozi/domain/policy/controller/PolicyController.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/controller/PolicyController.java
@@ -18,21 +18,9 @@ public class PolicyController {
     private final PolicyService policyService;
     private final ApiCaller apiCaller;
 
-    // 정책 API에서 받아와 DB에 저장
-    @PostMapping(value = "/fetch-and-save", produces = "text/plain; charset=UTF-8")
-    public ResponseEntity<String> fetchAndSave() {
-        String json = apiCaller.getJsonResponse();
-        List<PolicyDTO> dtoList = apiCaller.parseJsonToPolicies(json);
-        policyService.saveAll(dtoList);
-
-        return ResponseEntity.ok("정책 정보 DB 저장 완료됨!!");
-    }
-
     // 정책 전체 조회
     @GetMapping
     public ResponseEntity<List<PolicyDTO>> getAllPolicies() {
-//        List<PolicyDTO> list = policyService.findAll();
-//        return ResponseEntity.ok(list);
 
         List<PolicyDTO> list = policyService.findAll();
         return ResponseEntity.ok(list);
@@ -45,11 +33,21 @@ public class PolicyController {
         return ResponseEntity.ok(dto);
     }
 
+
+    // 필터 조건에 따른 정책 조회
     @PostMapping("/filter")
     public List<PolicyDTO> getFilteredPolicies(@RequestBody PolicyFilterDTO filters) {
         return policyService.getPoliciesByFilters(filters);
     }
 
 
-
+//    // 정책 API에서 받아와 DB에 저장(수동 버전.)
+//    @PostMapping(value = "/fetch-and-save", produces = "text/plain; charset=UTF-8")
+//    public ResponseEntity<String> fetchAndSave() {
+//        String json = apiCaller.getJsonResponse();
+//        List<PolicyDTO> dtoList = apiCaller.parseJsonToPolicies(json);
+//        policyService.saveAll(dtoList);
+//
+//        return ResponseEntity.ok("정책 정보 DB 저장 완료됨!!");
+//    }
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.java
@@ -9,10 +9,22 @@ import java.util.List;
 
 @Mapper
 public interface PolicyMapper {
+
+    // 전체 정책 목록 조회
     List<PolicyVO> findAll();
+
+    // 정책 고유번호로 중복 여부 확인
     int existsByPlcyNo(String plcyNo);
+
+    // 정책 DB에 insert
     void insertPolicy(PolicyVO policyVO);
 
+    // ID로 상세 조회
     PolicyVO selectPolicyById(int id);
+
+    // 필터 조건으로 정책 리스트 조회
     List<PolicyDTO> findByFilters(PolicyFilterDTO filters);
+
+    // 현재 DB에 저장된 정책 개수 반환
+    int count();
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/service/PolicyService.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/service/PolicyService.java
@@ -7,12 +7,17 @@ import java.util.List;
 
 public interface PolicyService {
 
+    // 전체 정책 목록 조회
     List<PolicyDTO> findAll();
 
+    // 전체 정책 목록 조회
     void saveAll(List<PolicyDTO> dtoList);
 
+    // 정책 저장 (중복 방지)
     PolicyDTO findById(int id);
 
+    // 필터 조건으로 정책 리스트 조회
     List<PolicyDTO> getPoliciesByFilters(PolicyFilterDTO filters);
+
 
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/util/ApiCaller.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/util/ApiCaller.java
@@ -14,14 +14,16 @@ import java.util.List;
 @Component
 public class ApiCaller {
 
+    // API 호출 URL과 인증키는 application.properties에서 주입받음
     @Value("${youth.api.url}")
     private String apiUrl;
 
     @Value("${youth.api.key}")
     private String apiKey;
 
+    // 실제 요청 최종 URL
     public String getRequestUrl() {
-        return apiUrl + "?apiKeyNm=" + apiKey + "&rtnType=json&pageNum=1&pageSize=200";
+        return apiUrl + "?apiKeyNm=" + apiKey + "&rtnType=json&pageNum=1&pageSize=300";
     }
 
     public String getJsonResponse() {
@@ -54,6 +56,7 @@ public class ApiCaller {
         return response.toString();
     }
 
+    // JSON 응답을 파싱하여 정책 DTO 리스트로 변환
     public List<PolicyDTO> parseJsonToPolicies(String json) {
         List<PolicyDTO> list = new ArrayList<>();
 

--- a/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.xml
+++ b/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.xml
@@ -13,6 +13,10 @@
         SELECT COUNT(*) FROM YouthPolicy WHERE plcyNo = #{plcyNo}
     </select>
 
+    <select id="count" resultType="int">
+        SELECT COUNT(*) FROM YouthPolicy
+    </select>
+
     <insert id="insertPolicy" parameterType="org.iebbuda.mozi.domain.policy.domain.PolicyVO">
         INSERT INTO YouthPolicy (
             plcyNm,
@@ -132,6 +136,7 @@
 
 
     </select>
+
 
 
 </mapper>


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [ ] 🐛 버그 수정
- [x] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항

### 무엇을 변경했나요?
- 정책 API 수동 DB 변환에서 서버 시작 시 자동으로 300개 저장되도록 변경.
- 전체 데이터 개수 4000개 처리에 대해서는 미완성(추후 다시 PR 올리겠습니다)


### 왜 이 변경이 필요한가요?
- [x] POST 요청하여 수동 저장이 불편함 




## 📌 리뷰 포인트

> **Warning**  
> 다음 사항들을 중점적으로 리뷰해주세요
- [x] 서버 시작 시 정책 300개 저장되는지 확인!

