### PR TITLE
bug: policy VO,mapper 오타 수정

### DIFF
--- a/src/main/java/org/iebbuda/mozi/domain/policy/controller/RegionCodeController.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/controller/RegionCodeController.java
@@ -15,6 +15,14 @@ public class RegionCodeController {
 
     private final RegionCodeService regionCodeService;
 
+
+    // 전체 지역 반환
+    @GetMapping
+    public List<RegionCodeVO> getAllRegionCodes() {
+        return regionCodeService.getAllRegionCodes();
+    }
+
+
     // zip 코드 리스트로 변환
     @PostMapping("/zipcodes")
     public List<String> getZipCodesByRegionNames(@RequestBody List<String> regionNames) {
@@ -27,10 +35,10 @@ public class RegionCodeController {
         return regionCodeService.getRegionNamesByZipCodes(zipCodes);
     }
 
-    // 전체 지역 반환
-    @GetMapping("/all")
-    public List<RegionCodeVO> getAllRegionCodes() {
-         return regionCodeService.getAllRegionCodes();
+    // 시도(sido) 기준 zip_code 전체 반환
+    @GetMapping("/zipcodes/sido")
+    public ResponseEntity<List<String>> getZipCodesBySido(@RequestParam String sido) {
+        return ResponseEntity.ok(regionCodeService.findZipCodesBySido(sido));
     }
 
 

--- a/src/main/java/org/iebbuda/mozi/domain/policy/domain/PolicyVO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/domain/PolicyVO.java
@@ -17,7 +17,7 @@ public class PolicyVO {
     private String schoolCd;           // 학력 (ENUM)
     private String jobCd;              // 취업 상태 (ENUM)
     private String plcyMajorCd;        // 전공 분야
-    private String sBizCd;             // 특화 분야
+    private String sbizCd;             // 특화 분야
     private String aplyUrlAddr;        // 신청 URL
     private String bizPrdBgngYmd;      // 시작일 (String으로 받고 저장 시 DATE로 변환)
     private String bizPrdEndYmd;       // 종료일

--- a/src/main/java/org/iebbuda/mozi/domain/policy/dto/PolicyDTO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/dto/PolicyDTO.java
@@ -17,7 +17,7 @@ public class PolicyDTO {
     private String schoolCd;           // 학력
     private String jobCd;              // 취업 상태
     private String plcyMajorCd;        // 전공 분야
-    private String sBizCd;             // 특화 분야
+    private String sbizCd;             // 특화 분야
     private String aplyUrlAddr;        // 신청 URL
     private String bizPrdBgngYmd;      // 시작일
     private String bizPrdEndYmd;       // 종료일

--- a/src/main/java/org/iebbuda/mozi/domain/policy/mapper/RegionCodeMapper.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/mapper/RegionCodeMapper.java
@@ -20,4 +20,7 @@ public interface RegionCodeMapper {
     // 전체 지역코드 리스트 조회
     List<RegionCodeVO> findAll();
 
+    // 시,도로 조회
+    List<String> findZipCodesBySido(String sido);
+
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/service/PolicyServiceImpl.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/service/PolicyServiceImpl.java
@@ -84,7 +84,7 @@ public class PolicyServiceImpl implements PolicyService {
         dto.setSchoolCd(vo.getSchoolCd());
         dto.setJobCd(vo.getJobCd());
         dto.setPlcyMajorCd(vo.getPlcyMajorCd());
-        dto.setSBizCd(vo.getSBizCd());
+        dto.setSbizCd(vo.getSbizCd());
         dto.setAplyUrlAddr(vo.getAplyUrlAddr());
         dto.setBizPrdBgngYmd(vo.getBizPrdBgngYmd());
         dto.setBizPrdEndYmd(vo.getBizPrdEndYmd());
@@ -113,7 +113,7 @@ public class PolicyServiceImpl implements PolicyService {
         vo.setSchoolCd(dto.getSchoolCd());
         vo.setJobCd(dto.getJobCd());
         vo.setPlcyMajorCd(dto.getPlcyMajorCd());
-        vo.setSBizCd(dto.getSBizCd());
+        vo.setSbizCd(dto.getSbizCd());
         vo.setAplyUrlAddr(dto.getAplyUrlAddr());
 
         // 날짜 공백 처리 추가

--- a/src/main/java/org/iebbuda/mozi/domain/policy/service/RegionCodeService.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/service/RegionCodeService.java
@@ -18,6 +18,7 @@ public interface RegionCodeService {
     // zipCd API 호출 후 저장
     void fetchAndSaveFromApi();
 
-
+    // 시, 도로 조회
+    List<String> findZipCodesBySido(String sido);
 
 }

--- a/src/main/java/org/iebbuda/mozi/domain/policy/service/RegionCodeServiceImpl.java
+++ b/src/main/java/org/iebbuda/mozi/domain/policy/service/RegionCodeServiceImpl.java
@@ -34,6 +34,13 @@ public class RegionCodeServiceImpl implements RegionCodeService {
         return regionCodeMapper.findAll();
     }
 
+    // 시, 도로 조회
+    @Override
+    public List<String> findZipCodesBySido(String sido) {
+        return regionCodeMapper.findZipCodesBySido(sido);
+    }
+
+
     // zipCd API 호출 후 저장
     @Override
     public void fetchAndSaveFromApi() {

--- a/src/main/java/org/iebbuda/mozi/domain/profile/controller/ProfileController.java
+++ b/src/main/java/org/iebbuda/mozi/domain/profile/controller/ProfileController.java
@@ -4,7 +4,9 @@ package org.iebbuda.mozi.domain.profile.controller;
 import lombok.RequiredArgsConstructor;
 import org.iebbuda.mozi.common.response.BaseResponse;
 import org.iebbuda.mozi.common.response.BaseResponseStatus;
+import org.iebbuda.mozi.domain.profile.domain.UserProfileVO;
 import org.iebbuda.mozi.domain.profile.dto.UserProfileInfoDTO;
+import org.iebbuda.mozi.domain.profile.mapper.UserProfileMapper;
 import org.iebbuda.mozi.domain.profile.service.UserProfileService;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -37,5 +39,14 @@ public class ProfileController {
         userProfileService.saveProfile(userId, data);
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
     }
+
+    // 정책 페이지에서 테스트용: userId로 직접 퍼스널 정보 조회 (인증 없음)
+    private final UserProfileMapper userProfileMapper;
+    @GetMapping("/test/{userId}")
+    public BaseResponse<UserProfileInfoDTO> getUserProfileByUserId(@PathVariable int userId) {
+        UserProfileVO vo = userProfileMapper.findByUserId(userId);
+        return new BaseResponse<>(UserProfileInfoDTO.of(vo));
+    }
+
 
 }

--- a/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.xml
+++ b/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/PolicyMapper.xml
@@ -17,7 +17,7 @@
         <result column="school_cd" property="schoolCd"/>
         <result column="job_cd" property="jobCd"/>
         <result column="plcy_major_cd" property="plcyMajorCd"/>
-        <result column="s_biz_cd" property="sBizCd"/>
+        <result column="sbiz_cd" property="sbizCd"/>
         <result column="aply_url_addr" property="aplyUrlAddr"/>
         <result column="biz_prd_bgng_ymd" property="bizPrdBgngYmd"/>
         <result column="biz_prd_end_ymd" property="bizPrdEndYmd"/>
@@ -56,7 +56,7 @@
         INSERT INTO YouthPolicy (
             plcy_nm, plcy_no, plcy_expln_cn, plcy_sprt_cn,
             zip_cd, mrg_stts_cd, school_cd, job_cd,
-            plcy_major_cd, s_biz_cd, aply_url_addr,
+            plcy_major_cd, sbiz_cd, aply_url_addr,
             biz_prd_bgng_ymd, biz_prd_end_ymd,
             lclsf_nm, mclsf_nm, plcy_kywd_nm,
             sprt_trgt_min_age, sprt_trgt_max_age,
@@ -64,7 +64,7 @@
         ) VALUES (
                      #{plcyNm}, #{plcyNo}, #{plcyExplnCn}, #{plcySprtCn},
                      #{zipCd}, #{mrgSttsCd}, #{schoolCd}, #{jobCd},
-                     #{plcyMajorCd}, #{sBizCd}, #{aplyUrlAddr},
+                     #{plcyMajorCd}, #{sbizCd}, #{aplyUrlAddr},
                      #{bizPrdBgngYmd}, #{bizPrdEndYmd},
                      #{lclsfNm}, #{mclsfNm}, #{plcyKywdNm},
                      #{sprtTrgtMinAge}, #{sprtTrgtMaxAge},

--- a/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/RegionCodeMapper.xml
+++ b/src/main/resources/org/iebbuda/mozi/domain/policy/mapper/RegionCodeMapper.xml
@@ -32,6 +32,12 @@
         SELECT * FROM RegionCode
     </select>
 
+    <select id="findZipCodesBySido" resultType="String" parameterType="string">
+        SELECT zip_code
+        FROM RegionCode
+        WHERE sido = #{sido}
+    </select>
+
     <delete id="truncateTable">
         TRUNCATE TABLE RegionCode
     </delete>


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [x] 🐛 버그 수정
- [ ] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항

### 무엇을 변경했나요?


**주요 변경사항:**


<details>
<summary>상세 변경 내용</summary>



</details>

### 왜 이 변경이 필요한가요?
컬럼명 오타로 인해 정책 api 불러와 테이블에 저장할 때 특화분야(sbiz_cd)만 null값으로 채워지는 현상 발생 




## 📌 리뷰 포인트
정책 테이블 sbiz_cd에 null값 없이 잘 들어와 지는지
> **Warning**  
