### PR TITLE
OAuth 구글, 네이버 추가

### DIFF
--- a/src/main/java/org/iebbuda/mozi/common/response/BaseResponseStatus.java
+++ b/src/main/java/org/iebbuda/mozi/common/response/BaseResponseStatus.java
@@ -60,13 +60,15 @@ public enum BaseResponseStatus {
     KAKAO_USER_INFO_REQUEST_FAILED(false, HttpStatus.BAD_GATEWAY.value(), "카카오 사용자 정보 요청에 실패했습니다."),
     KAKAO_TOKEN_EXTRACT_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "카카오 토큰 추출에 실패했습니다."),
 
-    // 구글 OAuth 관련 (나중에 추가할 때)
-    GOOGLE_TOKEN_REQUEST_FAILED(false, HttpStatus.BAD_GATEWAY.value(), "구글 액세스 토큰 요청에 실패했습니다."),
-    GOOGLE_USER_INFO_REQUEST_FAILED(false, HttpStatus.BAD_GATEWAY.value(), "구글 사용자 정보 요청에 실패했습니다."),
-
-    // 네이버 OAuth 관련 (나중에 추가할 때)
-    NAVER_TOKEN_REQUEST_FAILED(false, HttpStatus.BAD_GATEWAY.value(), "네이버 액세스 토큰 요청에 실패했습니다."),
+    // 네이버 OAuth 에러
+    NAVER_TOKEN_REQUEST_FAILED(false, HttpStatus.BAD_GATEWAY.value(), "네이버 토큰 요청에 실패했습니다."),
     NAVER_USER_INFO_REQUEST_FAILED(false, HttpStatus.BAD_GATEWAY.value(), "네이버 사용자 정보 요청에 실패했습니다."),
+    NAVER_TOKEN_EXTRACT_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "네이버 토큰 추출에 실패했습니다."),
+
+    // 구글 OAuth 에러
+    GOOGLE_TOKEN_REQUEST_FAILED(false, HttpStatus.BAD_GATEWAY.value(), "구글 토큰 요청에 실패했습니다."),
+    GOOGLE_USER_INFO_REQUEST_FAILED(false, HttpStatus.BAD_GATEWAY.value(), "구글 사용자 정보 요청에 실패했습니다."),
+    GOOGLE_TOKEN_EXTRACT_FAILED(false, HttpStatus.INTERNAL_SERVER_ERROR.value(), "구글 토큰 추출에 실패했습니다."),
 
     // 공통 에러
     DATABASE_CONSTRAINT_ERROR(false, HttpStatus.BAD_REQUEST.value(), "데이터 제약조건 위반입니다."),

--- a/src/main/java/org/iebbuda/mozi/domain/security/controller/OAuthController.java
+++ b/src/main/java/org/iebbuda/mozi/domain/security/controller/OAuthController.java
@@ -25,24 +25,28 @@ public class OAuthController {
         return new BaseResponse<>(result);
     }
 
-//    @GetMapping("/google/callback")
-//    public BaseResponse<AuthResultDTO> googleCallback(@RequestParam("code") String code) {
-//        AuthResultDTO result = oauthLoginService.processOAuthLogin("GOOGLE", code);
-//        return new BaseResponse<>(result);
-//    }
-//
-//    @GetMapping("/naver/callback")
-//    public BaseResponse<AuthResultDTO> naverCallback(@RequestParam("code") String code) {
-//        AuthResultDTO result = oauthLoginService.processOAuthLogin("NAVER", code);
-//        return new BaseResponse<>(result);
-//    }
+    // ===== 네이버 =====
+    @GetMapping("/naver/login-url")
+    public BaseResponse<String> getNaverLoginUrl() {
+        String loginUrl = oauthLoginService.getLoginUrl("NAVER");
+        return new BaseResponse<>(loginUrl);
+    }
 
-//    // 범용 OAuth 콜백 엔드포인트
-//    @GetMapping("/{provider}/callback")
-//    public BaseResponse<AuthResultDTO> oauthCallback(
-//            @PathVariable("provider") String provider,
-//            @RequestParam("code") String code) {
-//        AuthResultDTO result = oauthLoginService.processOAuthLogin(provider.toUpperCase(), code);
-//        return new BaseResponse<>(result);
-//    }
+    @GetMapping("/naver/callback")
+    public BaseResponse<AuthResultDTO> naverCallback(@RequestParam("code") String code) {
+        AuthResultDTO result = oauthLoginService.processOAuthLogin("NAVER", code);
+        return new BaseResponse<>(result);
+    }
+    // ===== 구글 =====
+    @GetMapping("/google/login-url")
+    public BaseResponse<String> getGoogleLoginUrl() {
+        String loginUrl = oauthLoginService.getLoginUrl("GOOGLE");
+        return new BaseResponse<>(loginUrl);
+    }
+
+    @GetMapping("/google/callback")
+    public BaseResponse<AuthResultDTO> googleCallback(@RequestParam("code") String code) {
+        AuthResultDTO result = oauthLoginService.processOAuthLogin("GOOGLE", code);
+        return new BaseResponse<>(result);
+    }
 }

--- a/src/main/java/org/iebbuda/mozi/domain/security/dto/oauth/GoogleUserInfoDTO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/security/dto/oauth/GoogleUserInfoDTO.java
@@ -1,0 +1,43 @@
+package org.iebbuda.mozi.domain.security.dto.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GoogleUserInfoDTO implements OAuthUserInfo{
+    private String id;
+    private String email;
+    private String name;
+
+    @JsonProperty("given_name")
+    private String givenName;
+
+    @JsonProperty("family_name")
+    private String familyName;
+
+    private String picture;
+    private String locale;
+
+    @JsonProperty("verified_email")
+    private Boolean verifiedEmail;
+
+
+    @Override
+    public String getProviderId() {
+        return this.id;
+    }
+
+    @Override
+    public String getNickname() {
+        // 구글의 경우 별도 닉네임이 없으므로 이름을 사용
+        return this.name;
+    }
+
+    @Override
+    public String getEmail() {
+        return this.email;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return OAuthProvider.GOOGLE;
+    }
+}

--- a/src/main/java/org/iebbuda/mozi/domain/security/dto/oauth/NaverUserInfoDTO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/security/dto/oauth/NaverUserInfoDTO.java
@@ -1,0 +1,56 @@
+package org.iebbuda.mozi.domain.security.dto.oauth;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class NaverUserInfoDTO implements OAuthUserInfo {
+    private String resultCode;
+    private String message;
+
+    @JsonProperty("response")
+    private NaverResponse response;
+
+
+    @Data
+    public static class NaverResponse {
+        private String id;
+        private String nickname;
+        private String email;
+        private String name;
+
+        @JsonProperty("profile_image")
+        private String profileImage;
+
+        private String gender;
+        private String age;
+        private String birthday;
+        private String birthyear;
+        private String mobile;
+    }
+
+    @Override
+    public String getProviderId() {
+        return response != null ? response.getId() : null;
+    }
+
+    @Override
+    public String getNickname() {
+        if (response != null) {
+            // 네이버는 이름(name)을 주로 사용, 닉네임이 없으면 이름 사용
+            return response.getName() != null ? response.getName() : response.getNickname();
+        }
+        return null;
+    }
+
+    @Override
+    public String getEmail() {
+        return response != null ? response.getEmail() : null;
+    }
+
+    @Override
+    public OAuthProvider getProvider() {
+        return OAuthProvider.NAVER;
+    }
+}

--- a/src/main/java/org/iebbuda/mozi/domain/security/service/oauth/GoogleOAuthService.java
+++ b/src/main/java/org/iebbuda/mozi/domain/security/service/oauth/GoogleOAuthService.java
@@ -1,0 +1,116 @@
+package org.iebbuda.mozi.domain.security.service.oauth;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j2;
+import org.iebbuda.mozi.common.response.BaseException;
+import org.iebbuda.mozi.common.response.BaseResponseStatus;
+import org.iebbuda.mozi.domain.security.dto.oauth.GoogleUserInfoDTO;
+import org.iebbuda.mozi.domain.security.dto.oauth.OAuthUserInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Log4j2
+@PropertySource("classpath:application.properties")
+public class GoogleOAuthService implements OAuthService{
+
+    @Value("${google.client.id}")
+    private String clientId;
+
+    @Value("${google.client.secret}")
+    private String clientSecret;
+
+    @Value("${google.redirect.uri}")
+    private String redirectUri;
+
+    private static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    private static final String GOOGLE_USER_INFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String getLoginUrl() {
+        return UriComponentsBuilder
+                .fromUriString("https://accounts.google.com/o/oauth2/auth")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("scope", "openid email profile")
+                .toUriString();
+    }
+
+    @Override
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(GOOGLE_TOKEN_URL, request, String.class);
+            return extractAccessToken(response.getBody());
+        } catch (Exception e) {
+            log.error("구글 액세스 토큰 요청 실패", e);
+            throw new BaseException(BaseResponseStatus.GOOGLE_TOKEN_REQUEST_FAILED);
+        }
+    }
+
+    @Override
+    public OAuthUserInfo getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<GoogleUserInfoDTO> response = restTemplate.exchange(
+                    GOOGLE_USER_INFO_URL,
+                    HttpMethod.GET,
+                    request,
+                    GoogleUserInfoDTO.class
+            );
+
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("구글 사용자 정보 요청 실패", e);
+            throw new BaseException(BaseResponseStatus.GOOGLE_USER_INFO_REQUEST_FAILED);
+        }
+    }
+
+    @Override
+    public boolean supports(String provider) {
+        return "GOOGLE".equalsIgnoreCase(provider);
+    }
+
+    private String extractAccessToken(String responseBody) {
+        try {
+            JsonNode rootNode = objectMapper.readTree(responseBody);
+            String accessToken = rootNode.path("access_token").asText();
+
+            if (accessToken.isEmpty()) {
+                throw new BaseException(BaseResponseStatus.GOOGLE_TOKEN_EXTRACT_FAILED);
+            }
+
+            return accessToken;
+        } catch (Exception e) {
+            log.error("구글 access_token 파싱 실패", e);
+            throw new BaseException(BaseResponseStatus.GOOGLE_TOKEN_EXTRACT_FAILED);
+        }
+    }
+}

--- a/src/main/java/org/iebbuda/mozi/domain/security/service/oauth/NaverOAuthService.java
+++ b/src/main/java/org/iebbuda/mozi/domain/security/service/oauth/NaverOAuthService.java
@@ -1,0 +1,115 @@
+package org.iebbuda.mozi.domain.security.service.oauth;
+
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j2;
+import org.iebbuda.mozi.common.response.BaseException;
+import org.iebbuda.mozi.common.response.BaseResponseStatus;
+import org.iebbuda.mozi.domain.security.dto.oauth.NaverUserInfoDTO;
+import org.iebbuda.mozi.domain.security.dto.oauth.OAuthUserInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+@Log4j2
+@PropertySource("classpath:application.properties")
+public class NaverOAuthService implements OAuthService{
+
+    @Value("${naver.client.id}")
+    private String clientId;
+
+    @Value("${naver.client.secret}")
+    private String clientSecret;
+
+    @Value("${naver.redirect.uri}")
+    private String redirectUri;
+
+    private static final String NAVER_TOKEN_URL = "https://nid.naver.com/oauth2.0/token";
+    private static final String NAVER_USER_INFO_URL = "https://openapi.naver.com/v1/nid/me";
+
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String getLoginUrl() {
+        return UriComponentsBuilder
+                .fromUriString("https://nid.naver.com/oauth2.0/authorize")
+                .queryParam("response_type", "code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .toUriString();
+    }
+    @Override
+    public String getAccessToken(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(NAVER_TOKEN_URL, request, String.class);
+            return extractAccessToken(response.getBody());
+        } catch (Exception e) {
+            log.error("네이버 액세스 토큰 요청 실패", e);
+            throw new BaseException(BaseResponseStatus.NAVER_TOKEN_REQUEST_FAILED);
+        }
+    }
+
+    @Override
+    public OAuthUserInfo getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<NaverUserInfoDTO> response = restTemplate.exchange(
+                    NAVER_USER_INFO_URL,
+                    HttpMethod.GET,
+                    request,
+                    NaverUserInfoDTO.class
+            );
+
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("네이버 사용자 정보 요청 실패", e);
+            throw new BaseException(BaseResponseStatus.NAVER_USER_INFO_REQUEST_FAILED);
+        }
+    }
+
+    @Override
+    public boolean supports(String provider) {
+        return "NAVER".equalsIgnoreCase(provider);
+    }
+
+
+    private String extractAccessToken(String responseBody) {
+        try {
+            JsonNode rootNode = objectMapper.readTree(responseBody);
+            String accessToken = rootNode.path("access_token").asText();
+
+            if (accessToken.isEmpty()) {
+                throw new BaseException(BaseResponseStatus.NAVER_TOKEN_EXTRACT_FAILED);
+            }
+
+            return accessToken;
+        } catch (Exception e) {
+            log.error("네이버 access_token 파싱 실패", e);
+            throw new BaseException(BaseResponseStatus.NAVER_TOKEN_EXTRACT_FAILED);
+        }
+    }
+}


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [ ] 🐛 버그 수정
- [x] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항

### 무엇을 변경했나요?
**주요 변경사항:**
-  네이버, 구글 OAuth 2.0 소셜 로그인 기능 구현
- JWT 기반 인증 시스템과 OAuth 연동
- OAuth 사용자 자동 회원가입 및 로그인 처리
- BaseResponse 형태의 통일된 API 응답 구조

<details>
<summary>상세 변경 내용</summary>

**OAuth 서비스 계층:**
- `OAuthService` 인터페이스 및 구현체 (`KakaoOAuthService`, `NaverOAuthService`, `GoogleOAuthService`)
- `OAuthServiceFactory` - OAuth 제공자별 서비스 팩토리 패턴 적용
- `OAuthLoginService` - OAuth 로그인 통합 처리 서비스
- `OAuthUserService` - OAuth 사용자 정보 처리 및 자동 회원가입

**DTO 및 도메인:**
- `OAuthUserInfo` 인터페이스 및 제공자별 구현체
- `OAuthProvider` enum - 지원하는 OAuth 제공자 정의
- `AuthResultDTO` - 로그인 결과 응답 DTO

**컨트롤러:**
- `OAuthController` - OAuth 로그인 URL 제공 및 콜백 처리 엔드포인트

**보안 설정:**
- 기존 JWT 인증 시스템과 OAuth 연동
- OAuth 콜백 엔드포인트 보안 설정

**데이터베이스:**
- 사용자 테이블에 `provider`, `provider_id` 컬럼 추가 (OAuth 사용자 식별용)
- OAuth 사용자 조회를 위한 `UserMapper` 메서드 추가

</details>

### 왜 이 변경이 필요한가요?
- [x] 사용자 편의성 향상 - 복잡한 회원가입 과정 없이 소셜 계정으로 간편 로그인
- [x] 사용자 유입 증대 - 소셜 로그인을 통한 가입 장벽 낮춤
- [x] 보안 강화 - OAuth 2.0 표준 프로토콜 사용으로 안전한 인증
- [x] 사용자 정보 신뢰성 - 이미 검증된 소셜 플랫폼의 사용자 정보 활용

## 📸 스크린샷 (필요한 경우)
<!-- 소셜 로그인 UI 또는 API 응답 예시 스크린샷 첨부 -->

## ✅ 체크리스트
- [x] 코드 작성 완료
- [x] OAuth 제공자별 서비스 구현 (네이버, 구글)
- [x] JWT 토큰 발급 및 사용자 정보 응답 구현
- [x] 예외 처리 및 에러 응답 구현
- [x] BaseResponse 응답 형태 통일
- [x] OAuth 사용자 자동 회원가입 로직 구현
- [x] 이메일 중복 검사 및 처리 로직 구현
- [ ] 단위 테스트 작성
- [ ] 통합 테스트 작성

## 🔗 관련 이슈
#53 

## 📌 리뷰 포인트

## 🚀 테스트 방법

```bash
# 1. OAuth 설정 파일 준비
cp application.properties.example application.properties
# OAuth 클라이언트 ID/Secret 설정 필요

# 2. 애플리케이션 실행
./gradlew bootRun

# 3. OAuth 로그인 URL 요청 테스트
curl -X GET "http://localhost:8080/api/oauth/kakao/login-url"
curl -X GET "http://localhost:8080/api/oauth/naver/login-url"  
curl -X GET "http://localhost:8080/api/oauth/google/login-url"

# 4. 각 개발자센터에서 콜백 URL 설정 확인
# - 카카오: https://developers.kakao.com
# - 네이버: https://developers.naver.com  
# - 구글: https://console.cloud.google.com
```

**수동 테스트 순서:**
1. 브라우저에서 로그인 URL 접속
2. 각 소셜 플랫폼에서 로그인 진행
3. 콜백 처리 및 JWT 토큰 발급 확인
4. 발급된 토큰으로 인증이 필요한 API 호출 테스트

## 🔧 설정 요구사항

**application.properties 설정 예시:**
```properties
# 카카오 OAuth
kakao.client.id=YOUR_KAKAO_CLIENT_ID
kakao.client.secret=YOUR_KAKAO_CLIENT_SECRET
kakao.redirect.uri=http://localhost:8080/oauth/kakao/callback

# 네이버 OAuth  
naver.client.id=YOUR_NAVER_CLIENT_ID
naver.client.secret=YOUR_NAVER_CLIENT_SECRET
naver.redirect.uri=http://localhost:8080/oauth/naver/callback

# 구글 OAuth
google.client.id=YOUR_GOOGLE_CLIENT_ID
google.client.secret=YOUR_GOOGLE_CLIENT_SECRET  
google.redirect.uri=http://localhost:8080/oauth/google/callback
```


## 🚨 주의사항
- OAuth 클라이언트 시크릿 키는 절대 공개 저장소에 커밋하지 않도록 주의
- 각 OAuth 제공자의 개발자센터에서 콜백 URL을 정확히 설정해야 함
- 프로덕션 환경에서는 HTTPS 사용 필수