### PR TITLE
feat: 메인페이지 계좌 보여주기 console에러 제거

### DIFF
--- a/src/main/java/org/iebbuda/mozi/domain/account/dto/BankSummaryDTO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/account/dto/BankSummaryDTO.java
@@ -12,6 +12,9 @@ import lombok.NoArgsConstructor;
 public class BankSummaryDTO {
     private String bankCode;
     private Integer accountCount;
-    private Double totalBalance;
-    private String representativeAccountName;
+    @Builder.Default
+    private Double totalBalance = 0.0;
+
+    @Builder.Default
+    private String representativeAccountName = "";
 }

--- a/src/main/java/org/iebbuda/mozi/domain/account/service/AccountServiceImpl.java
+++ b/src/main/java/org/iebbuda/mozi/domain/account/service/AccountServiceImpl.java
@@ -243,6 +243,9 @@ public class AccountServiceImpl implements AccountService {
         }
 
         boolean success = (mainSummary != null);
+        if(mainSummary == null) {
+            mainSummary=new BankSummaryDTO();
+        }
         return Map.of(
                 "mainBankCode", mainBankCode,
                 "success", success,


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [x ] 🐛 버그 수정
- [] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항

### 무엇을 변경했나요?
메인페이지 계좌 보여주기 console에러 제거
메인페이지 보여줄 계좌가 없을 때 console창 에러(response에 null값이 포함돼서)가 뜸.이를 제거함


