### PR TITLE
feat: 유저 로그인 정보 기반 스크랩 기능 연동

### DIFF
--- a/src/main/java/org/iebbuda/mozi/domain/scrap/controller/FinancialScrapController.java
+++ b/src/main/java/org/iebbuda/mozi/domain/scrap/controller/FinancialScrapController.java
@@ -8,6 +8,8 @@ import org.iebbuda.mozi.domain.scrap.dto.FinancialScrapDto;
 import org.iebbuda.mozi.domain.scrap.service.DepositScrapService;
 import org.iebbuda.mozi.domain.scrap.service.FinancialScrapService;
 import org.iebbuda.mozi.domain.scrap.service.SavingScrapService;
+import org.iebbuda.mozi.domain.security.account.domain.CustomUser;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -21,23 +23,27 @@ public class FinancialScrapController {
 
     // 스크랩 목록 조회
     @GetMapping
-    public List<FinancialScrapDto> getUserScraps(@RequestParam Long userId) {
+    public List<FinancialScrapDto> getUserScraps(@AuthenticationPrincipal CustomUser user) {
+        long userId= (long) user.getUser().getUserId();
+        System.out.println("userId체크: "+userId);
         return financialScrapService.getUserScraps(userId);
     }
 
     // 스크랩 추가
     @PostMapping
-    public void addScrap(@RequestParam Long userId,
+    public void addScrap(@AuthenticationPrincipal CustomUser user,
                          @RequestParam String productType,
                          @RequestParam Long productId) {
+        long userId= (long) user.getUser().getUserId();
         financialScrapService.addScrap(userId, productType, productId);
     }
 
     // 스크랩 삭제
     @DeleteMapping
-    public void removeScrap(@RequestParam Long userId,
+    public void removeScrap(@AuthenticationPrincipal CustomUser user,
                             @RequestParam String productType,
                             @RequestParam Long productId) {
+        long userId= (long) user.getUser().getUserId();
         financialScrapService.removeScrap(userId, productType, productId);
     }
 }


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [ ] 🐛 버그 수정
- [x] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항

### 무엇을 변경했나요?
- 보안 및 일관된 인증 처리를 위해 @AuthenticationPrincipal CustomUser user로 대체하여, 인증된 사용자 정보에서 userId를 조회하도록 변경

**주요 변경사항:**
- 직접 UserId를 받는 방식에서 SecurityContextHolder에서 토큰을 통한 유저 정보를 조회하는 방식으로 변경



### 왜 이 변경이 필요한가요?
- [x] 유저 로그인 정보에 따라 스크랩 정보를 다르게 저장하기 위함


> **Note**  

## ✅ 체크리스트
- [x] 로그인 유저별 스크랩 정보 개별 저장 여부 확인
- [x]
## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 연결해주세요 -->
<!-- Related to #이슈번호 -->
#86 
## 📌 리뷰 포인트

> **Warning**  
> 다음 사항들을 중점적으로 리뷰해주세요
- [x]

## 🚀 테스트 방법

```bash
