### PR TITLE
회원가입 이후 프로필 등록 프롬포트 

### DIFF
--- a/src/main/java/org/iebbuda/mozi/domain/profile/controller/ProfileController.java
+++ b/src/main/java/org/iebbuda/mozi/domain/profile/controller/ProfileController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.iebbuda.mozi.common.response.BaseResponse;
 import org.iebbuda.mozi.common.response.BaseResponseStatus;
 import org.iebbuda.mozi.domain.profile.domain.UserProfileVO;
+import org.iebbuda.mozi.domain.profile.dto.PersonalInfoStatusDTO;
 import org.iebbuda.mozi.domain.profile.dto.UserProfileInfoDTO;
 import org.iebbuda.mozi.domain.profile.mapper.UserProfileMapper;
 import org.iebbuda.mozi.domain.profile.service.UserProfileService;
@@ -38,6 +39,16 @@ public class ProfileController {
         String userId = userDetails.getUsername();
         userProfileService.saveProfile(userId, data);
         return new BaseResponse<>(BaseResponseStatus.SUCCESS);
+    }
+
+
+    @GetMapping("/status")
+    public BaseResponse<PersonalInfoStatusDTO> getPersonalInfoStatus(
+            @AuthenticationPrincipal UserDetails userDetails) {
+
+        String loginId = userDetails.getUsername();
+        PersonalInfoStatusDTO status = userProfileService.getPersonalInfoStatus(loginId);
+        return new BaseResponse<>(status);
     }
 
     // 정책 페이지에서 테스트용: userId로 직접 퍼스널 정보 조회 (인증 없음)

--- a/src/main/java/org/iebbuda/mozi/domain/profile/dto/PersonalInfoStatusDTO.java
+++ b/src/main/java/org/iebbuda/mozi/domain/profile/dto/PersonalInfoStatusDTO.java
@@ -1,0 +1,29 @@
+package org.iebbuda.mozi.domain.profile.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PersonalInfoStatusDTO {
+
+    @JsonProperty("has_personal_info")
+    private boolean hasPersonalInfo;        // 퍼스널 정보 입력 여부
+
+    @JsonProperty("created_at")
+    private LocalDateTime createdAt;        // 가입일
+
+    @JsonProperty("days_remaining")
+    private Integer daysRemaining;          // 남은 일수 (14일 기준)
+
+    @JsonProperty("needs_prompt")
+    private boolean needsPrompt;            // 프롬프트 표시 필요 여부
+
+}

--- a/src/main/java/org/iebbuda/mozi/domain/profile/service/UserProfileService.java
+++ b/src/main/java/org/iebbuda/mozi/domain/profile/service/UserProfileService.java
@@ -1,5 +1,6 @@
 package org.iebbuda.mozi.domain.profile.service;
 
+import org.iebbuda.mozi.domain.profile.dto.PersonalInfoStatusDTO;
 import org.iebbuda.mozi.domain.profile.dto.UserProfileInfoDTO;
 
 import java.util.Map;
@@ -7,5 +8,5 @@ import java.util.Map;
 public interface UserProfileService {
     void saveProfile(String loginId, UserProfileInfoDTO dto);
     UserProfileInfoDTO getUserProfile(String userId);
-
+    PersonalInfoStatusDTO getPersonalInfoStatus(String loginId);
 }

--- a/src/main/java/org/iebbuda/mozi/domain/security/config/SecurityConfig.java
+++ b/src/main/java/org/iebbuda/mozi/domain/security/config/SecurityConfig.java
@@ -120,6 +120,21 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers("/api/users/password/verify-email-code").permitAll() // 비밀번호 재설정 이메일 인증 확인
                 .antMatchers("/api/users/password/verify-account").permitAll()  // 계정 확인
                 .antMatchers("/api/users/password/reset").permitAll()          // 비밀번호 재설정
+                .antMatchers("/api/deposits").permitAll()
+                .antMatchers("/api/deposits/{id}").permitAll()
+                .antMatchers("/api/deposits/top").permitAll()
+                .antMatchers("/api/savings").permitAll()
+                .antMatchers("/api/savings/{id}").permitAll()
+                .antMatchers("/api/savings/top").permitAll()
+                .antMatchers("/api/policy").permitAll()
+                .antMatchers("/api/policy/{id}").permitAll()
+                .antMatchers("/api/policy/filter").permitAll()
+                .antMatchers("/api/policy/deadline").permitAll()
+                .antMatchers("/api/region").permitAll()
+                .antMatchers("/api/region/zipcodes").permitAll()
+                .antMatchers("/api/region/names").permitAll()
+                .antMatchers("/api/region/zipcodes/sido").permitAll()
+
 
                 // OAuth 관련 API들
                 .antMatchers("/api/oauth/**").permitAll()                      // OAuth 로그인 (카카오, 구글, 네이버 등)


### PR DESCRIPTION
## 📋 PR 유형
<!-- 해당하는 것에 ✅ 표시해주세요 -->
- [ ] 🐛 버그 수정
- [x] ✨ 새 기능 구현
- [ ] 📚 문서 업데이트
- [ ] 🔧 코드 리팩토링
- [ ] 🎨 스타일 변경
- [ ] ⚡ 성능 개선

## 📝 변경 사항
- 메인 페이지에 퍼스널 입력으로 유도하는 프롬포트 등록



**주요 변경사항:**
- 회원의 상태(회원 가입 날짜, 퍼스널 정보 입력 유무)를 알 수 있는 api 추가
- service, controller, dto 추가

**왜 필요한가?:**
- 사용자가 회원가입 이후 서비스를 이용하기 위해서는 거의 필수로 프로필 정보가 이용됨
- 그렇기 때문에 회원 가입 후 14일이 지나지 않은 회원들은 프로필 정보 입력으로 유도

